### PR TITLE
Update github output syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
       run: |
         DIR=$(pwd)
         tmp_dir=$(mktemp -d --tmpdir=${DIR})
-        echo "::set-output name=name::${tmp_dir}"
+        echo "name=${tmp_dir}" >> $GITHUB_OUTPUT
 
     - name: Checkout Private actions
       uses: actions/checkout@v3


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/