### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-dev-environment.yml
+++ b/.github/workflows/test-dev-environment.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -50,12 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'cplive-plat-ue2-dev-eks-cluster'
           actual: "${{ needs.test.outputs.cluster }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'dev'
           actual: "${{ needs.test.outputs.namespace }}"

--- a/.github/workflows/test-staging-environment.yml
+++ b/.github/workflows/test-staging-environment.yml
@@ -28,7 +28,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -50,12 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'cplive-plat-ue2-dev-eks-cluster'
           actual: "${{ needs.test.outputs.cluster }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'staging'
           actual: "${{ needs.test.outputs.namespace }}"

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
         echo "name=${tmp_dir}" >> $GITHUB_OUTPUT
 
     - name: Checkout Private actions
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: ${{ inputs.implementation_repository }}
         ref: ${{ inputs.implementation_ref }}


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

Supersedes #26
Supersedes #25

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
